### PR TITLE
Add: Video Info api

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -47,7 +47,7 @@ def get_videos_info():
             return jsonify('VideoId is needed'), 400
 
         with Session(engine) as session:
-            result = session.query(
+            info = session.query(
                 Video.id,
                 Video.title ,
                 Channel.channel_id,
@@ -100,7 +100,9 @@ def get_videos_info():
                         .join(Video, Video.id == VideoStat.video_id)\
                             .join(Channel, Channel.channel_id == Video.channel_id).all()
 
-        return jsonify(dict(result[0])), 200
+        result = dict(info[0]) if info else []
+
+        return jsonify(result), 200
 
     except Exception as e:
         return jsonify(e), 400

--- a/controller.py
+++ b/controller.py
@@ -1,9 +1,9 @@
-from sqlalchemy import select
+from sqlalchemy import select, and_
 from sqlalchemy.orm import Session
 
 from flask import request, jsonify
 from database import engine
-from models import Video
+from models import Video, VideoStat, Channel
 
 
 def search_video_by_title():
@@ -41,4 +41,66 @@ def search_video_by_title():
 
 
 def get_videos_info():
-    pass
+    try:
+        video_id = request.args.get('vid', None)
+        if not video_id:
+            return jsonify('VideoId is needed'), 400
+
+        with Session(engine) as session:
+            result = session.query(
+                Video.id,
+                Video.title ,
+                Channel.channel_id,
+                VideoStat.stat_type,
+                VideoStat.from_date,
+                VideoStat.to_date,
+                VideoStat.created_at,
+                VideoStat.updated_at,
+                VideoStat.deleted_at,
+                VideoStat.impressions,
+                # VideoStat.impression_click_rate,
+                VideoStat.views,
+                VideoStat.views_subs,
+                VideoStat.views_unsubs,
+                VideoStat.views_red,
+                VideoStat.avg_per_viewed,
+                VideoStat.avg_per_viewed_subs,
+                VideoStat.avg_per_viewed_unsubs,
+                VideoStat.avg_per_viewed_red,
+                VideoStat.avg_view_duration,
+                VideoStat.video_length,
+                VideoStat.watch_time,
+                VideoStat.watch_time_red,
+                VideoStat.subs_gain,
+                VideoStat.subs_lost,
+                VideoStat.subs,
+                VideoStat.likes,
+                VideoStat.dislikes,
+                VideoStat.comment,
+                VideoStat.sharing,
+                VideoStat.playlist_add,
+                VideoStat.playlist_remove,
+                VideoStat.end_screen_shown,
+                VideoStat.end_screen_click,
+                VideoStat.click_per_end_screen_shown,
+                VideoStat.card_shown,
+                VideoStat.card_click,
+                VideoStat.card_click_rate,
+                VideoStat.est_partner_rev,
+                VideoStat.est_partner_ad_rev,
+                VideoStat.est_partner_red_rev,
+                VideoStat.est_partner_super_rev,
+                VideoStat.ad_impressions,
+                VideoStat.est_monetized_playbacks,
+                VideoStat.cpm,
+                # VideoStat.cpm_playback_base,
+                VideoStat.unique_viewer
+                )\
+                    .filter(and_(VideoStat.video_id == video_id, VideoStat.stat_type == 'THREEDAYS'))\
+                        .join(Video, Video.id == VideoStat.video_id)\
+                            .join(Channel, Channel.channel_id == Video.channel_id).all()
+
+        return jsonify(dict(result[0])), 200
+
+    except Exception as e:
+        return jsonify(e), 400


### PR DESCRIPTION
1. 수정사항
- 입력받은 video id 와 stat_type인 THREEDAYS 로 filtering하여 private_videos_stat 테이블의 내용을 가져왔습니다. join을 통해 channel id와 video id, title을 출력했습니다.

2. 의문사항
- videostat 을 가져올 때, impression_click_rate 칼럼과 cpm_playback_base 칼럼을 호출할 때 칼럼 인식을 못하는데 이 부분 해결을 못해서 일단 주석 처리 했습니다.